### PR TITLE
VEAF MCT - error when adding AI planes to the mission

### DIFF
--- a/Script/DCS extensions/UnitCallsignMaker.lua
+++ b/Script/DCS extensions/UnitCallsignMaker.lua
@@ -225,7 +225,7 @@ do
         for _,g in ipairs(missionGroups) do
             if g.units and g.units[1] then
                 local unit = g.units[1]
-                if unit.callsign and unit.callsign[1] and unit.callsign.name then
+                if unit.callsign and type(unit.callsign) == "table" and unit.callsign.name then
                     local callsignName = unit.callsign.name:sub(1, #unit.callsign.name - 2)
                     incrementCallsign(callsignName, unit.callsign[2])
                 end


### PR DESCRIPTION
Fixes VEAF/the-universal-mission-for-dcs-world#1

After converting the TUM mission to add the VEAF Mission Creation Tools, an error was raised because the injected AI aircrafts (for CAP spawn) callsigns were numeric (as for all RED callsigns).