### PR TITLE
Make the radio menu isolated (optional)

### DIFF
--- a/Script/Script.lua
+++ b/Script/Script.lua
@@ -15,6 +15,8 @@ TUM.logLevel = {
     ERROR = 2
 }
 
+TUM.USE_SPECIFIC_RADIOMENU = true -- Use a specific radio menu for the mission commands, or use the main one?
+
 -------------------------------------
 -- Prints and logs a debug message
 -- @param message The message
@@ -36,6 +38,22 @@ function TUM.log(message, logLevel)
 
         env.info("TUM: "..message, false)
     end
+end
+
+TUM.rootMenu = nil
+function TUM.getOrCreateRootMenu(reset) -- Get or create the root menu for the mission commands; if reset is true, the menu will be cleared and recreated
+    if reset then
+        missionCommands.removeItem(TUM.rootMenu) -- Clear the menu
+        TUM.rootMenu = nil
+        TUM.getOrCreateRootMenu() -- Recreate the root menu
+    end
+    if not TUM.rootMenu then
+        if TUM.USE_SPECIFIC_RADIOMENU then
+            local rootMenuTitle = "✈ TUM"
+            TUM.rootMenu = missionCommands.addSubMenu(rootMenuTitle)
+        end
+    end
+    return TUM.rootMenu
 end
 
 --[[DCS EXTENSIONS]]--

--- a/Script/The Universal Mission/DebugMenu.lua
+++ b/Script/The Universal Mission/DebugMenu.lua
@@ -93,8 +93,7 @@ do
 
     function TUM.debugMenu.createMenu()
         if not TUM.DEBUG_MODE then return end
-
-        local rootMenu = missionCommands.addSubMenu("[DEBUG]")
+        local rootMenu = missionCommands.addSubMenu("[DEBUG]", TUM.getOrCreateRootMenu())
         missionCommands.addCommand("Detonate - BOOM map markers", rootMenu, doMarkersBoom, nil)
         missionCommands.addCommand("Detonate - AIRBOOM map markers", rootMenu, doMarkersAirBoom, nil)
         missionCommands.addCommand("Wingman - kill", rootMenu, doKillWingman, nil)

--- a/Script/The Universal Mission/Intermission.lua
+++ b/Script/The Universal Mission/Intermission.lua
@@ -86,7 +86,7 @@ do
     -- Creates the mission briefing menu
     -------------------------------------
     function TUM.intermission.createMenu()
-        missionCommands.removeItem() -- Clear the menu
+        local rootMenu = TUM.getOrCreateRootMenu(true) -- Clear the menu
 
         local briefingText = "Welcome to The Universal Mission for DCS World, a highly customizable mission available for single-player and PvE.\n\nOpen the communication menu and select the ''F10. Other'' option to access mission settings."
         DCSEx.envMission.setBriefing(coalition.side.RED, briefingText)
@@ -94,9 +94,9 @@ do
 
         TUM.intermission.createMissionZonesMarkers() -- Show the available mission zones on the F10 map
 
-        missionCommands.addCommand("ℹ Display mission settings", nil, TUM.settings.printSettingsSummary, false)
+        missionCommands.addCommand("ℹ Display mission settings", rootMenu, TUM.settings.printSettingsSummary, false)
 
-        local settingsMenu = missionCommands.addSubMenu("✎ Change mission settings")
+        local settingsMenu = missionCommands.addSubMenu("✎ Change mission settings", rootMenu)
         createSubMenu(TUM.settings.id.COALITION_BLUE, settingsMenu)
         createSubMenu(TUM.settings.id.COALITION_RED, settingsMenu)
         createSubMenu(TUM.settings.id.TASKING, settingsMenu)
@@ -107,7 +107,7 @@ do
         createSubMenu(TUM.settings.id.WINGMEN, settingsMenu)
         createSubMenu(TUM.settings.id.AI_CAP, settingsMenu)
         TUM.playerCareer.createMenu()
-        missionCommands.addCommand("➤ Begin mission", nil, doCommandStartMission, nil)
+        missionCommands.addCommand("➤ Begin mission", rootMenu, doCommandStartMission, nil)
         TUM.debugMenu.createMenu() -- Append debug menu to other menus (if debug mode enabled)
     end
 

--- a/Script/The Universal Mission/MissionMenu.lua
+++ b/Script/The Universal Mission/MissionMenu.lua
@@ -34,11 +34,11 @@ do
     end
 
     function TUM.missionMenu.create()
-        missionCommands.removeItem() -- Clear the menu
-        missionCommands.addCommand("☱ Mission status", nil, doCommandMissionStatus, nil)
+        local rootMenu = TUM.getOrCreateRootMenu(true) -- Clear the menu
+        missionCommands.addCommand("☱ Mission status", rootMenu, doCommandMissionStatus, nil)
 
-        local objectivesMenuRoot = missionCommands.addSubMenu("❖ Objectives")
-        local navigationMenuRoot = missionCommands.addSubMenu("➽ Navigation")
+        local objectivesMenuRoot = missionCommands.addSubMenu("❖ Objectives", rootMenu)
+        local navigationMenuRoot = missionCommands.addSubMenu("➽ Navigation", rootMenu)
         -- missionCommands.addCommand("Nav to nearest airbase", navigationMenuRoot, doCommandNearestAirbase, nil)
 
         for i=1,TUM.objectives.getCount() do
@@ -57,10 +57,10 @@ do
         TUM.supportAWACS.createMenu()
 
         if not TUM.settings.getValue(TUM.settings.id.MULTIPLAYER) then -- If not multiplayer, add "show mission score" command
-            missionCommands.addCommand("★ Display mission score", nil, TUM.playerScore.showScore, nil)
+            missionCommands.addCommand("★ Display mission score", rootMenu, TUM.playerScore.showScore, nil)
         end
 
-        local abortRoot = missionCommands.addSubMenu("⬣ Abort mission")
+        local abortRoot = missionCommands.addSubMenu("⬣ Abort mission", rootMenu)
         if not TUM.settings.getValue(TUM.settings.id.MULTIPLAYER) and DCSEx.io.canReadAndWrite() then
             missionCommands.addCommand("✓ Confirm (all xp since last landing will be lost!)", abortRoot, doCommandAbortMission, nil)
         else

--- a/Script/The Universal Mission/PlayerCareer.lua
+++ b/Script/The Universal Mission/PlayerCareer.lua
@@ -146,10 +146,11 @@ do
     -- Appends the career menu to the F10 menu. Only works in single-player missions
     -------------------------------------
     function TUM.playerCareer.createMenu()
+        local rootMenu = TUM.getOrCreateRootMenu()
         if not DCSEx.io.canReadAndWrite() then return end -- IO disabled, career and scoring disabled
         if TUM.settings.getValue(TUM.settings.id.MULTIPLAYER) then return end -- No career in multiplayer
 
-        missionCommands.addCommand("✪ View pilot career stats", nil, TUM.playerCareer.displayMedalBox, true)
+        missionCommands.addCommand("✪ View pilot career stats", rootMenu, TUM.playerCareer.displayMedalBox, true)
     end
 
     -------------------------------------

--- a/Script/The Universal Mission/SupportAWACS.lua
+++ b/Script/The Universal Mission/SupportAWACS.lua
@@ -91,8 +91,9 @@ do
 
     function TUM.supportAWACS.createMenu()
         if not awacsGroupID then return end -- No AWACS
+        local rootMenu = TUM.getOrCreateRootMenu()
 
-        local rootPath = missionCommands.addSubMenu("⌾ Awacs")
+        local rootPath = missionCommands.addSubMenu("⌾ Awacs", rootMenu)
         missionCommands.addCommand("Bogey dope", rootPath, doCommandBogeyDope, nil)
         missionCommands.addCommand("Picture", rootPath, doCommandPicture, nil)
     end

--- a/Script/The Universal Mission/WingmenMenu.lua
+++ b/Script/The Universal Mission/WingmenMenu.lua
@@ -75,11 +75,12 @@ do
     end
 
     function TUM.wingmenMenu.create()
+        local rootMenu = TUM.getOrCreateRootMenu()
         if TUM.settings.getValue(TUM.settings.id.MULTIPLAYER) then return end -- No wingmen in multiplayer
         if TUM.settings.getValue(TUM.settings.id.WINGMEN) <= 1 then return end -- No wingmen
         local isWW2 = (TUM.settings.getValue(TUM.settings) == DCSEx.enums.timePeriod.WORLD_WAR_2) -- Some options are different when time period is WW2
 
-        local rootPath = missionCommands.addSubMenu("✈ Flight")
+        local rootPath = missionCommands.addSubMenu("✈ Flight", rootMenu)
         missionCommands.addCommand("Cover me!", rootPath, radioCommandCoverMe, nil)
 
         ------------------------------------------------------


### PR DESCRIPTION
I've added code to isolate the radio menu.

Instead of having all the commands directly in the DCS main radio menu (and clearing it each time the situation changes, thus removing all the other items), TUM has its own menu, isolated from the other scripts menus.

This is useful if the mission maker wants to add menus for triggers, or uses other scripts like CTLD or the VEAF MCT.

This behavior is optional (`TUM.USE_SPECIFIC_RADIOMENU`)